### PR TITLE
Padronização de ícones, fontes, botões e estilização do código

### DIFF
--- a/lib/telabiblioteca.dart
+++ b/lib/telabiblioteca.dart
@@ -25,7 +25,7 @@ class _telabibliotecaState extends State<telabiblioteca> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            Image.asset('imagem/logosibiunivasf.jpg',),
+            // Image.asset('imagem/logosibiunivasf.jpg',),
             SizedBox(
               height: 20,
             ),
@@ -36,9 +36,16 @@ class _telabibliotecaState extends State<telabiblioteca> {
               },
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
+                  ),
+                  
                   Text(
-                    ' Petrolina'),
+                    ' Petrolina', 
+                    style: const TextStyle(fontSize: 20),
+                  ),
                 ],
               ),
               style: ButtonStyle(
@@ -70,9 +77,15 @@ class _telabibliotecaState extends State<telabiblioteca> {
               },
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
+                  ),
+                  
                   Text(
-                    ' Juazeiro',
+                    ' Juazeiro', 
+                    style: const TextStyle(fontSize: 20),
                   ),
                 ],
               ),
@@ -103,10 +116,17 @@ class _telabibliotecaState extends State<telabiblioteca> {
               },
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
-                  Text(
-                    ' Biblioteca Espaço Plural',
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
                   ),
+                  
+                  Text(
+                    ' Biblioteca Espaço Plural', 
+                    style: const TextStyle(fontSize: 20),
+                  ),
+
                 ],
               ),
               style: ButtonStyle(
@@ -136,9 +156,15 @@ class _telabibliotecaState extends State<telabiblioteca> {
               },
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
+                  ),
+                  
                   Text(
-                    ' Senhor do Bonfim',
+                    ' Senhor do Bonfim', 
+                    style: const TextStyle(fontSize: 20),
                   ),
                 ],
               ),
@@ -169,9 +195,15 @@ class _telabibliotecaState extends State<telabiblioteca> {
               },
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
+                  ),
+                  
                   Text(
-                    ' Paulo Afonso',
+                    ' Paulo Afonso', 
+                    style: const TextStyle(fontSize: 20),
                   ),
                 ],
               ),
@@ -200,10 +232,17 @@ class _telabibliotecaState extends State<telabiblioteca> {
                   builder: (context) => salgueiro()));},
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
-                  Text(
-                    ' Salgueiro',
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
                   ),
+                  
+                  Text(
+                    ' Salgueiro', 
+                    style: const TextStyle(fontSize: 20),
+                  ),
+
                 ],
               ),
               style: ButtonStyle(
@@ -233,9 +272,15 @@ class _telabibliotecaState extends State<telabiblioteca> {
               },
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
+                  ),
+                  
                   Text(
-                    ' Serra da Capivara',
+                    ' São Raimundo Notato', 
+                    style: const TextStyle(fontSize: 20),
                   ),
                 ],
               ),
@@ -266,9 +311,15 @@ class _telabibliotecaState extends State<telabiblioteca> {
               },
               child: Row(
                 children: [
-                  Icon(Icons.account_balance),
+                  
+                  Icon(
+                    Icons.account_balance,
+                    size: 30.0,
+                  ),
+                  
                   Text(
-                    ' Ciências Agrárias',
+                    ' Campus de Ciências Agrárias', 
+                    style: const TextStyle(fontSize: 20),
                   ),
                 ],
               ),

--- a/lib/teladelinks.dart
+++ b/lib/teladelinks.dart
@@ -42,7 +42,7 @@ class _teladelinksState extends State<teladelinks> {
             mainAxisSize: MainAxisSize.min,
 
             children: [
-              Image.asset('imagem/logosibiunivasf.jpg'),
+              // Image.asset('imagem/logosibiunivasf.jpg'),
               SizedBox(
                 height: 20,
               ),
@@ -53,9 +53,15 @@ class _teladelinksState extends State<teladelinks> {
                 },
                 child: Row(
                   children: [
-                    Icon(Icons.person_outline),
+                    
+                    Icon(
+                      Icons.person_outline,
+                      size: 30.0,
+                    ),
+                    
                     Text(
-                      ' Guia Do Usuario',
+                      ' Guia do Usuário', 
+                      style: const TextStyle(fontSize: 20),
                     ),
                   ],
                 ),
@@ -67,7 +73,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -87,8 +93,16 @@ class _teladelinksState extends State<teladelinks> {
                 },
                 child: Row(
                   children: [
-                    Icon(Icons.search_outlined),
-                    Text(' Como Consultar o Pergamun?')
+                    
+                    Icon(
+                      Icons.search_outlined,
+                      size: 30.0
+                    ),
+                    
+                    Text(
+                      ' Como Consultar o Pergamum?', 
+                      style: const TextStyle(fontSize: 20),
+                    )
                   ],
                 ),
                 style: ButtonStyle(
@@ -99,7 +113,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -120,8 +134,16 @@ class _teladelinksState extends State<teladelinks> {
                 },
                 child: Row(
                   children: [
-                    Image.asset('imagem/icones/social.png',width: 25,color: Colors.white, ),
-                    Text('  Redes Sociais'),
+                    
+                    Icon(
+                      Icons.polyline,
+                      size: 30.0,
+                    ),
+                    
+                    Text(
+                      ' Redes Sociais', 
+                      style: const TextStyle(fontSize: 20),
+                    ),
                   ],
                 ),
                 style: ButtonStyle(
@@ -132,7 +154,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -153,8 +175,16 @@ class _teladelinksState extends State<teladelinks> {
                 },
                 child: Row(
                   children: [
-                    Icon(Icons.collections_bookmark_outlined),
-                    Text(' Documentos SIBI'),
+                    
+                    Icon(
+                      Icons.collections_bookmark_outlined,
+                      size: 30.0,
+                    ),
+                    
+                    Text(
+                      ' Documentos SIBI', 
+                      style: const TextStyle(fontSize: 20),
+                    ),
                   ],
                 ),
                 style: ButtonStyle(
@@ -165,7 +195,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -184,8 +214,16 @@ class _teladelinksState extends State<teladelinks> {
                       builder: (context) => telacatolgrafica()));
                 },
                 child: Row(children: [
-                  Icon(Icons.drafts),
-                  Text(' Ficha Catolografica')
+                  
+                  Icon(
+                    Icons.drafts,
+                    size: 30.0,
+                  ),
+                  
+                  Text(
+                    ' Ficha Catalográfica', 
+                    style: const TextStyle(fontSize: 20),
+                  )
                 ]),
                 style: ButtonStyle(
                     shape: MaterialStateProperty.resolveWith((states) {
@@ -195,7 +233,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -215,8 +253,16 @@ class _teladelinksState extends State<teladelinks> {
                 },
                 child: Row(
                   children: [
-                    Icon(Icons.school),
-                    Text(' Declaração Nada Consta')
+                    
+                    Icon(
+                      Icons.check,
+                      size: 30.0,
+                    ),
+                    
+                    Text(
+                      ' Declaração Nada Consta', 
+                      style: const TextStyle(fontSize: 20),
+                    )
                   ],
                 ),
                 style: ButtonStyle(
@@ -227,7 +273,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -247,8 +293,16 @@ class _teladelinksState extends State<teladelinks> {
                 },
                 child: Row(
                   children: [
-                    Icon(Icons.border_color_outlined),
-                    Text(' Manual de Normalização'),
+                    
+                    Icon(
+                      Icons.border_color_outlined,
+                      size: 30.0,
+                    ),
+                    
+                    Text(
+                      ' Manual de Normalização', 
+                      style: const TextStyle(fontSize: 20),
+                    ),
                   ],
                 ),
                 style: ButtonStyle(
@@ -259,7 +313,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -274,10 +328,19 @@ class _teladelinksState extends State<teladelinks> {
               ),
               ElevatedButton(
                 onPressed: () { Navigator.of(context).push(MaterialPageRoute(
-                    builder: (context) => telatutoriais()));},
+                    builder: (context) => telatutoriais()));
+                },
                 child: Row(children: [
-                  Icon(Icons.subscriptions),
-                  Text(' Tutoriais')
+                  
+                  Icon(
+                    Icons.school,
+                    size: 30.0,
+                  ),
+                  
+                  Text(
+                    ' Tutoriais', 
+                    style: const TextStyle(fontSize: 20),
+                  )
                 ]),
                 style: ButtonStyle(
                     shape: MaterialStateProperty.resolveWith((states) {
@@ -287,7 +350,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {
@@ -307,8 +370,15 @@ class _teladelinksState extends State<teladelinks> {
                 },
                 child: Row(
                   children: [
-                    Icon(Icons.touch_app_outlined),
-                    Text(' Reserva e Renovação de Livros')
+                    
+                    Icon(
+                      Icons.touch_app_outlined,
+                      size: 30.0,
+                    ),
+                    
+                    Text(' Reserva e Renovação de Livros', 
+                        style: const TextStyle(fontSize: 20),
+                    )
                   ],
                 ),
                 style: ButtonStyle(
@@ -319,7 +389,7 @@ class _teladelinksState extends State<teladelinks> {
                     }), // Muda as Bordas
                     fixedSize:
                     MaterialStateProperty.resolveWith<Size?>((states) {
-                      return Size(_L,_H);
+                      return Size(400, 70);
                     }), //tamanho
                     backgroundColor:
                     MaterialStateProperty.resolveWith<Color?>((states) {


### PR DESCRIPTION
# Padronização de ícones, fontes, botões e estilização do código na tela de listagem das bibliotecas e na tela do menu
- Padroniza tamanho das fontes para 20
- Padroniza o tamanho dos ícones para 30.0
- Modifica alguns ícones para outros mais intuitivos
- Estiliza o código a fim de ficar mais legível e de melhorar a identação